### PR TITLE
Add back `overwrite` to fix `ParameterAlreadyExists` error

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,4 +17,6 @@ resource "aws_ssm_parameter" "this" {
   value  = each.value.value
   key_id = each.value.type != "SecureString" ? null : concat(data.aws_kms_key.this.*.arn, [""])[0]
   tags   = var.tags
+  # TODO: remove after migration to aws provider v6.x
+  overwrite = true
 }


### PR DESCRIPTION
Together with changes in AWS-provider `v5.0.0` a buggy behavior was introduced when parameter is update.
We have to set `overwrite = true` till it is removed in upcomming version.

> To prepare for v6.0.0, configurations where overwrite is used to adopt ownership of existing resources can add an import block to make the operation explicit. Configurations where overwrite is set to false to prevent updates can change to an ignore_changes lifecycle block. Lastly, and unfortunately, configurations expecting the standard update flow will need to keep overwrite = true set until this becomes the default behavior in v6.0.0. Removing it in v5.X will result in the default value of false, preventing the parameter value from being updated, causing persistent differences.

Links:
- https://github.com/hashicorp/terraform-provider-aws/issues/25636